### PR TITLE
remove params from prep-s2d vm extension

### DIFF
--- a/301-storage-spaces-direct/nestedtemplates/deploy-s2d-cluster.json
+++ b/301-storage-spaces-direct/nestedtemplates/deploy-s2d-cluster.json
@@ -301,23 +301,12 @@
       "properties": {
         "publisher": "Microsoft.Powershell",
         "type": "DSC",
-        "typeHandlerVersion": "2.20",
+        "typeHandlerVersion": "2.73",
         "autoUpgradeMinorVersion": true,
         "settings": {
           "modulesUrl": "[variables('s2dPrepModulesURL')]",
           "configurationFunction": "[variables('s2dPrepFunction')]",
-          "properties": {
-            "domainName": "[parameters('domainName')]",
-            "adminCreds": {
-              "userName": "[parameters('adminUsername')]",
-              "password": "PrivateSettingsRef:adminPassword"
-            }
-          }
-        },
-        "protectedSettings": {
-          "items": {
-            "adminPassword": "[parameters('adminPassword')]"
-          }
+          "properties": {}
         }
       }
     },
@@ -334,7 +323,7 @@
       "properties": {
         "publisher": "Microsoft.Powershell",
         "type": "DSC",
-        "typeHandlerVersion": "2.20",
+        "typeHandlerVersion": "2.73",
         "autoUpgradeMinorVersion": true,
         "settings": {
           "modulesUrl": "[variables('s2dConfigModulesURL')]",


### PR DESCRIPTION
With the updated file, prep-s2d no longer needs any parameters. Also updated typeHanderVersion to 2.73 (latest) for better error reporting.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

